### PR TITLE
Fixing socket binding exception when using replyport parameter

### DIFF
--- a/qosreflect.py
+++ b/qosreflect.py
@@ -70,7 +70,7 @@ if conf['host'] == 'All':
 else:
     HOST = conf['host']
 if args.replyport:
-    PORT = args.replyport
+    PORT = int(args.replyport)
 else:
     PORT = int(conf['port'])
 


### PR DESCRIPTION
Casting the replyport command line arg to an integer otherwise using the argument fails to bind the socket to this port number as an integer is expected